### PR TITLE
Handle expired sessions

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -68,7 +68,9 @@ class TokenSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = TokenModel
-        fields = ("key", "id", "username", "photo_url")
+        # Include field "key" once frontend actually uses token auth
+        # instead of the current session auth
+        fields = ("id", "username", "photo_url")
 
     def get_photo_url(self, obj):
         if not obj.user.avatar:

--- a/frontend/cypress/integration/stubbed/auth.spec.js
+++ b/frontend/cypress/integration/stubbed/auth.spec.js
@@ -1,0 +1,14 @@
+/// <reference types="cypress" />
+
+context("Stubbed Auth", () => {
+  beforeEach(() => {
+    cy.stubbedSetup();
+    cy.visit("/boards/");
+  });
+
+  it("should show login view after clicking logout via user menu", () => {
+    cy.findByTestId("user-menu").click();
+    cy.findByText(/Logout/i).click();
+    cy.findByTestId("open-login-btn").should("be.visible");
+  });
+});

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -28,7 +28,6 @@ Cypress.Commands.add("stubbedSetup", () => {
     JSON.stringify({
       auth: {
         user: {
-          key: "7b324ec07e049bc7e81a5a40c0606a07bc30f82c",
           id: 1,
           username: "testuser",
           photo_url: null

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,6 @@ import { BrowserRouter as Router } from "react-router-dom";
 
 import FullPageSpinner from "components/FullPageSpinner";
 import Toast from "features/toast/Toast";
-
 import { theme } from "./const";
 import store, { RootState } from "./store";
 

--- a/frontend/src/api.tsx
+++ b/frontend/src/api.tsx
@@ -1,8 +1,21 @@
 import axios from "axios";
+import { logout } from "features/auth/AuthSlice";
 
 // Config global defaults for axios/django
 axios.defaults.xsrfHeaderName = "X-CSRFToken";
 axios.defaults.xsrfCookieName = "csrftoken";
+
+export const setupInterceptors = (store: any) => {
+  axios.interceptors.response.use(
+    response => response,
+    error => {
+      if (error.response.status === 401) {
+        store.dispatch(logout());
+      }
+      return Promise.reject(error);
+    }
+  );
+};
 
 // Available endpoints
 export const API_LOGIN = "/dj-rest-auth/login/";

--- a/frontend/src/api.tsx
+++ b/frontend/src/api.tsx
@@ -9,6 +9,7 @@ export const setupInterceptors = (store: any) => {
   axios.interceptors.response.use(
     response => response,
     error => {
+      // Handle expired sessions
       if (error.response.status === 401) {
         store.dispatch(logout());
       }

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -53,6 +53,7 @@ const UserMenu = () => {
         aria-controls="user-menu"
         aria-haspopup="true"
         onClick={handleClick}
+        data-testid="user-menu"
         css={css`
           min-width: 1.5rem;
           padding: 0;

--- a/frontend/src/const.ts
+++ b/frontend/src/const.ts
@@ -1,6 +1,6 @@
 import { createMuiTheme } from "@material-ui/core/styles";
 import { Priority, PriorityValue } from "types";
-import { PRIO1, PRIO2, PRIO3 } from "utils/colors";
+import { PRIO1, PRIO2, PRIO3, PRIMARY, SECONDARY } from "utils/colors";
 
 export const LOCAL_STORAGE_KEY = "knboard-v12";
 export const TOAST_AUTO_HIDE_DURATION = 4000;
@@ -106,7 +106,14 @@ export const QUILL_FORMATS = [
 ];
 
 export const theme = createMuiTheme({
-  palette: {},
+  palette: {
+    primary: {
+      main: PRIMARY
+    },
+    secondary: {
+      main: SECONDARY
+    }
+  },
   transitions: {
     create: () => "none"
   },

--- a/frontend/src/features/auth/AuthSlice.tsx
+++ b/frontend/src/features/auth/AuthSlice.tsx
@@ -81,9 +81,10 @@ export const logout = createAsyncThunk(
   async (_, { dispatch }) => {
     try {
       await api.post(API_LOGOUT);
-      dispatch(createInfoToast("Logged out"));
     } catch (err) {
       dispatch(createErrorToast(err.toString()));
+    } finally {
+      dispatch(createInfoToast("Logged out"));
     }
   }
 );
@@ -111,6 +112,9 @@ export const slice = createSlice({
       state.loginLoading = false;
     });
     builder.addCase(logout.fulfilled, state => {
+      state.user = null;
+    });
+    builder.addCase(logout.rejected, state => {
       state.user = null;
     });
     builder.addCase(updateUser.fulfilled, (state, action) => {

--- a/frontend/src/features/profile/Profile.test.tsx
+++ b/frontend/src/features/profile/Profile.test.tsx
@@ -7,7 +7,8 @@ import {
   axiosMock
 } from "utils/testHelpers";
 import { API_USERS } from "api";
-import { User, UserDetail } from "types";
+import { UserDetail } from "types";
+import { steveAuthUser } from "features/auth/Auth.test";
 
 /* eslint-disable @typescript-eslint/camelcase */
 const steveDetail: UserDetail = {
@@ -18,12 +19,6 @@ const steveDetail: UserDetail = {
   email: "steve@gmail.com",
   avatar: null,
   date_joined: new Date().toISOString()
-};
-
-const steveAuthUser: User = {
-  id: 1,
-  username: "steve",
-  photo_url: null
 };
 
 it("should handle null userDetail", () => {

--- a/frontend/src/features/profile/Profile.test.tsx
+++ b/frontend/src/features/profile/Profile.test.tsx
@@ -21,7 +21,6 @@ const steveDetail: UserDetail = {
 };
 
 const steveAuthUser: User = {
-  key: "627a1758dff1cdde4f52578b0b6fdbf7b1c6d9b6",
   id: 1,
   username: "steve",
   photo_url: null

--- a/frontend/src/routing.tsx
+++ b/frontend/src/routing.tsx
@@ -1,0 +1,5 @@
+import { createBrowserHistory } from "history";
+
+const history = createBrowserHistory();
+
+export default history;

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -9,8 +9,8 @@ import boardReducer from "./features/board/BoardSlice";
 import columnReducer from "./features/column/ColumnSlice";
 import taskReducer from "./features/task/TaskSlice";
 import memberReducer from "./features/member/MemberSlice";
-
 import authInitialState from "./features/auth/AuthSlice";
+import { setupInterceptors } from "api";
 
 export const rootReducer = combineReducers({
   auth: authReducer,
@@ -30,9 +30,6 @@ const store = configureStore({
 
 store.subscribe(() => {
   const state = store.getState();
-
-  // TODO: Currently user object is saved to LocalStore and user is
-  // considered logged in if exists, but exipred sessions aren't dealt with
   saveState({
     auth: {
       ...authInitialState,
@@ -40,6 +37,8 @@ store.subscribe(() => {
     }
   });
 });
+
+setupInterceptors(store);
 
 export type RootState = ReturnType<typeof rootReducer>;
 export type AppThunk = ThunkAction<void, RootState, null, Action<string>>;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -52,7 +52,6 @@ export interface TasksByColumn {
 }
 
 export interface User {
-  key: string;
   id: number;
   username: string;
   photo_url: string | null;

--- a/frontend/src/utils/colors.ts
+++ b/frontend/src/utils/colors.ts
@@ -1,5 +1,6 @@
 // Palette
 export const PRIMARY = "#263590";
+export const SECONDARY = "#89DAFF";
 
 // Priority
 export const PRIO1 = "#D74981";


### PR DESCRIPTION
Add a response interceptor to dispatch a `logout` when 401 is received. This should handle expired sessions.

Also remove saving token to localstorage as currently only session auth is used.