### PR TITLE
support deleting board

### DIFF
--- a/frontend/cypress/integration/stubbed/board.spec.js
+++ b/frontend/cypress/integration/stubbed/board.spec.js
@@ -56,6 +56,9 @@ context("Board Detail (Member)", () => {
       cy.findAllByTestId("board-name-textarea").should("not.exist");
     });
   });
+  it("should not see delete board button", () => {
+    cy.findAllByTestId("delete-board").should("not.exist");
+  });
 });
 
 context("Board Detail (Owner)", () => {
@@ -230,6 +233,24 @@ context("Board Detail (Owner)", () => {
       cy.get(".MuiAutocomplete-popper").within(() => {
         cy.findByText(member.username).should("have.value", "");
       });
+    });
+  });
+  it("should delete board", () => {
+    const stub = cy.stub();
+    stub.onFirstCall().returns(true);
+    cy.on("window:confirm", stub);
+    cy.fixture("internals_board").then((board) => {
+      cy.route("DELETE", `/api/boards/${board.id}/`, "");
+
+      cy.findByText(board.name).should("be.visible");
+
+      cy.findByTestId(`board`).within(() => {
+        cy.findByTestId("delete-board").click();
+      });
+
+      cy.findAllByText(board.name).should("not.exist");
+      cy.findByText("All Boards").should("be.visible");
+      cy.findByText(/Create new board/i).should("be.visible");
     });
   });
 });

--- a/frontend/src/features/board/BoardBar.tsx
+++ b/frontend/src/features/board/BoardBar.tsx
@@ -6,6 +6,7 @@ import { barHeight } from "const";
 import { AvatarGroup } from "@material-ui/lab";
 import { css } from "@emotion/core";
 import { avatarStyles } from "styles";
+import { useHistory } from "react-router-dom";
 import BoardName from "components/BoardName";
 import MemberInvite from "features/member/MemberInvite";
 import MemberDetail from "features/member/MemberDetail";
@@ -17,10 +18,11 @@ import { Button } from "@material-ui/core";
 import { PRIMARY } from "utils/colors";
 import { addColumn } from "features/column/ColumnSlice";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPlus, faPen } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faPen, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { setDialogOpen } from "features/label/LabelSlice";
 import LabelDialog from "features/label/LabelDialog";
 import { useParams } from "react-router-dom";
+import { deleteBoard } from "features/board/BoardSlice";
 import {
   selectAllMembers,
   setMemberListOpen,
@@ -64,6 +66,7 @@ const buttonStyles = css`
 
 const BoardBar = () => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const members = useSelector(selectAllMembers);
   const error = useSelector((state: RootState) => state.board.detailError);
   const detail = useSelector((state: RootState) => state.board.detail);
@@ -81,6 +84,17 @@ const BoardBar = () => {
 
   const handleEditLabels = () => {
     dispatch(setDialogOpen(true));
+  };
+
+  const handleDelete = () => {
+    if (
+      window.confirm(
+        "Are you sure? Deleting the board will also delete related columns and tasks, and this cannot be undone."
+      )
+    ) {
+      dispatch(deleteBoard(id));
+      history.push("/boards");
+    }
   };
 
   return (
@@ -149,6 +163,20 @@ const BoardBar = () => {
           >
             Add Column
           </Button>
+          {boardOwner && (
+            <Button
+              size="small"
+              css={css`
+                ${buttonStyles}
+                font-weight: 600;
+              `}
+              startIcon={<FontAwesomeIcon icon={faTrash} />}
+              data-testid="delete-board"
+              onClick={handleDelete}
+            >
+              Delete Board
+            </Button>
+          )}
         </Right>
       </Items>
       <MemberDialog board={detail} />

--- a/frontend/src/features/board/BoardSlice.tsx
+++ b/frontend/src/features/board/BoardSlice.tsx
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction, createAsyncThunk } from "@reduxjs/toolkit";
 import { Board, IColumn, Id, ITask, Label, NanoBoard } from "types";
 import api, { API_BOARDS } from "api";
+import { createInfoToast } from "features/toast/ToastSlice";
 import { RootState } from "store";
 import { logout } from "features/auth/AuthSlice";
 
@@ -39,6 +40,15 @@ export const patchBoard = createAsyncThunk<
   const response = await api.patch(`${API_BOARDS}${id}/`, fields);
   return response.data;
 });
+
+export const deleteBoard = createAsyncThunk<Id, Id>(
+  "board/deleteBoardStatus",
+  async (id, { dispatch }) => {
+    await api.delete(`${API_BOARDS}${id}/`);
+    dispatch(createInfoToast("Board deleted"));
+    return id;
+  }
+);
 
 interface ColumnsResponse extends IColumn {
   tasks: ITask[];
@@ -145,6 +155,16 @@ export const slice = createSlice({
       }
       state.detailError = undefined;
       state.detailLoading = false;
+    });
+    builder.addCase(deleteBoard.fulfilled, (state, action) => {
+      const indexOfDeletedBoard = state.all.findIndex((obj) => {
+        if (obj.id == action.payload) {
+          return true;
+        }
+        return false;
+      });
+      state.all.splice(indexOfDeletedBoard, 1);
+      state.detail = null;
     });
     builder.addCase(logout.fulfilled, (state) => {
       state.all = [];

--- a/frontend/src/features/column/ColumnSlice.tsx
+++ b/frontend/src/features/column/ColumnSlice.tsx
@@ -3,7 +3,7 @@ import {
   createEntityAdapter,
   createAsyncThunk,
 } from "@reduxjs/toolkit";
-import { fetchBoardById } from "features/board/BoardSlice";
+import { deleteBoard, fetchBoardById } from "features/board/BoardSlice";
 import { IColumn, Id } from "types";
 import api, { API_SORT_COLUMNS, API_COLUMNS } from "api";
 import { createErrorToast, createInfoToast } from "features/toast/ToastSlice";
@@ -74,6 +74,9 @@ export const slice = createSlice({
     });
     builder.addCase(deleteColumn.fulfilled, (state, action) => {
       columnAdapter.removeOne(state, action.payload);
+    });
+    builder.addCase(deleteBoard.fulfilled, (state) => {
+      columnAdapter.removeAll(state);
     });
   },
 });


### PR DESCRIPTION
Fix #52

I just implement a small feature with simple UI, deleting a board, I hope you don't mind. 
Could you kindly review it?

Question: Currently, column stats are deleted once a board is deleted. I am not sure whether task, comment, member and label states should be deleted as well. Do you have any suggestions?
If they are expected to be deleted, besides adding the following snippet in each single slice function, is there other ways?
```
    builder.addCase(deleteBoard.fulfilled, (state) => {
      columnAdapter.removeAll(state);
    });
```


Deleting a board is a dangerous operation, so it's better to `close board` first and then delete closed board like [deleting-a-board in trello](https://help.trello.com/article/801-deleting-a-board).
But it will introduce more effort to implement more feature as follow,

1. Close a board
2. List closed boards
2. Re-open a closed board
3. Delete a closed board permanently
4. [Optional] Add a nested menu bar showing `close board`
5. etc.
